### PR TITLE
Fixed MergeOnly

### DIFF
--- a/.github/workflows/merge_only.yml
+++ b/.github/workflows/merge_only.yml
@@ -27,11 +27,13 @@ jobs:
       
       - name: Setup Params
         env:
-          ALGOLIA_APP_ID: "ALGOLIA_APP_ID: 'error'"
-          ALGOLIA_APP_KEY: "ALGOLIA_APP_KEY: 'error'"
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_APP_KEY: ${{ secrets.ALGOLIA_APP_KEY }}
+          MAG_KEY: ${{ secrets.MAG_KEY_PAIR }}
         run: |
           echo "${ALGOLIA_APP_ID}" >> params.yaml
           echo "${ALGOLIA_APP_KEY}" >> params.yaml
+          echo "${MAG_KEY}" >> params.yaml
           
       - name: Run DVC Pipeline
         run: dvc repro -f --downstream combine

--- a/LabeledData/convert_with_api.py
+++ b/LabeledData/convert_with_api.py
@@ -87,7 +87,7 @@ def get_api_data(dataframe: pd.DataFrame):
         print("Progress: {0:0.2%}".format(i/total_size))
 
         r = requests.get(url + paper_dois[i])
-    
+
         if (r.status_code == 200):
             temp_response = json.loads(r.text)
             api_res.append(temp_response)
@@ -266,6 +266,8 @@ if __name__ == "__main__":
     dataframe = pd.read_csv(args.csv_path, encoding="utf8")
     dataframe = dataframe.dropna(subset="url").fillna("")
     dataframe = dataframe.sort_values("petalID", axis=0, ascending=True)
+    dataframe["doi"] = dataframe["doi"] \
+        .apply(lambda doi: re.search(r'\b(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![\"&\'<>])\S)+)\b', doi).group().upper())
     (api_res, api_dois) = get_api_data(dataframe)
     golden_jsons = convert_to_json(dataframe, api_res, api_dois)
     

--- a/LabeledData/single_update.csv
+++ b/LabeledData/single_update.csv
@@ -1,2 +1,0 @@
-﻿paper,mag_terms,venue_mag,author,reference,title,abstract,petalID,doi,venue_names,label_level_1,label_level_2,label_level_3,url,isBiomimicry,fullDocLink,isOpenAccess
-,,,,,,,9860,10.1002/jmri.23717,,,,,https://onlinelibrary.wiley.com/doi/pdf/10.1002/jmri.23717,Y,,

--- a/LabeledData/single_update.csv
+++ b/LabeledData/single_update.csv
@@ -1,0 +1,2 @@
+﻿paper,mag_terms,venue_mag,author,reference,title,abstract,petalID,doi,venue_names,label_level_1,label_level_2,label_level_3,url,isBiomimicry,fullDocLink,isOpenAccess
+,,,,,,,9860,10.1002/jmri.23717,,,,,https://onlinelibrary.wiley.com/doi/pdf/10.1002/jmri.23717,Y,,

--- a/dvc.lock
+++ b/dvc.lock
@@ -3,36 +3,33 @@ stages:
   combine:
     cmd: python combine_csvs_and_jsons.py
     deps:
-    - path: ../AskNature/taxonomy/converted_paper.csv
-      md5: 6381677f2503f7b3530b71139a536c20
-      size: 3331
     - path: combine_csvs_and_jsons.py
-      md5: 22a689386bfe0cdbe5a062fd2516d1e3
-      size: 1059
+      md5: f6a935efe7e0d8f33177ffef45d5c48f
+      size: 1019
     outs:
     - path: merged_dataframes.csv
       md5: e61e9e0ce59c715d0886d62fa798c1b0
-      size: 266
+      size: 264
   convert:
     cmd: python convert_with_api.py merged_dataframes.csv ../Update/new_data
     deps:
     - path: convert_with_api.py
-      md5: 6aeb04f1064cd3d07a186a6d7ef1745b
-      size: 10661
+      md5: fd15c13c4cf6719bbc9e9eb29767e258
+      size: 10286
     - path: merged_dataframes.csv
       md5: e61e9e0ce59c715d0886d62fa798c1b0
-      size: 266
+      size: 264
     outs:
     - path: ../Update/new_data.json
-      md5: 6dc1e512ee4027a1ec1a0f77f9888aa6
-      size: 2951
+      md5: 0ceee1d2501d9dd883aeac510a44af5d
+      size: 2949
   update:
     cmd: python update_golden.py https://raw.githubusercontent.com/nasa-petal/data-collection-and-prep/main/golden
       new_data ../FinalFile/new_golden
     deps:
     - path: new_data.json
-      md5: 6dc1e512ee4027a1ec1a0f77f9888aa6
-      size: 2951
+      md5: 0ceee1d2501d9dd883aeac510a44af5d
+      size: 2949
     - path: update_golden.py
       md5: 8310b9ac0745597205c9a66c29a10242
-      size: 3556
+      size: 3460

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,78 +1,38 @@
 schema: '2.0'
 stages:
-  pullAskNature:
-    cmd: python algolia-downloader.py ask_nature_paper KK25DU67ZI bbd06cdca060a9aff6e5f52cf0ecab21
-    deps:
-    - path: algolia-downloader.py
-      md5: 9c7a89ad5014acae2a15c7dc0ccb0832
-      size: 5689
-    outs:
-    - path: ask_nature_paper.csv
-      md5: 4c3817538f67f06035ac6f49c32d3596
-      size: 5580
-  getDOIs:
-    cmd: python get_dois.py ../algolia_downloader/ask_nature_paper.csv
-    deps:
-    - path: ../algolia_downloader/ask_nature_paper.csv
-      md5: 4c3817538f67f06035ac6f49c32d3596
-      size: 5580
-    - path: get_dois.py
-      md5: 760924a4e6b42ffb2d0f8156134edf31
-      size: 2921
-    outs:
-    - path: doi_scraped_papers.csv
-      md5: 4c3817538f67f06035ac6f49c32d3596
-      size: 5580
-  convertAskNatureTaxonomy:
-    cmd: python AskNature/taxonomy/taxonomy_converter.py AskNature/doi_scraper/doi_scraped_papers.csv
-      AskNature/taxonomy/function_map.csv LabeledData/converted_paper
-    deps:
-    - path: AskNature/doi_scraper/doi_scraped_papers.csv
-      md5: 4c3817538f67f06035ac6f49c32d3596
-      size: 5580
-    - path: AskNature/taxonomy/taxonomy_converter.py
-      md5: 7f4509d1cdcfdecbc1e3d9852a16fdf5
-      size: 5962
-    outs:
-    - path: AskNature/taxonomy/converted_paper.csv
-      md5: 6381677f2503f7b3530b71139a536c20
-      size: 3331
-    - path: LabeledData/converted_paper.csv
-      md5: 6381677f2503f7b3530b71139a536c20
-      size: 3331
   combine:
     cmd: python combine_csvs_and_jsons.py
     deps:
+    - path: ../AskNature/taxonomy/converted_paper.csv
+      md5: 6381677f2503f7b3530b71139a536c20
+      size: 3331
     - path: combine_csvs_and_jsons.py
-      md5: f6a935efe7e0d8f33177ffef45d5c48f
-      size: 1019
+      md5: 22a689386bfe0cdbe5a062fd2516d1e3
+      size: 1059
     outs:
     - path: merged_dataframes.csv
-      md5: 1f5b0b3047f1a0d657fca11a4310b55a
-      size: 205
+      md5: e61e9e0ce59c715d0886d62fa798c1b0
+      size: 266
   convert:
     cmd: python convert_with_api.py merged_dataframes.csv ../Update/new_data
     deps:
     - path: convert_with_api.py
-      md5: a044f83ab7d0a6ef0497fced3e02f6db
-      size: 10632
+      md5: 6aeb04f1064cd3d07a186a6d7ef1745b
+      size: 10661
     - path: merged_dataframes.csv
-      md5: 9febb61548cc66c0fb87c63a21ce1515
-      size: 819238
+      md5: e61e9e0ce59c715d0886d62fa798c1b0
+      size: 266
     outs:
     - path: ../Update/new_data.json
-      md5: 18e2da136e2e1022855506ffbb8c2630
-      size: 4352437
+      md5: 6dc1e512ee4027a1ec1a0f77f9888aa6
+      size: 2951
   update:
-    cmd: python update_golden.py ../FinalFile/golden new_data ../FinalFile/new_golden
+    cmd: python update_golden.py https://raw.githubusercontent.com/nasa-petal/data-collection-and-prep/main/golden
+      new_data ../FinalFile/new_golden
     deps:
     - path: new_data.json
-      md5: a70ee7632dca658be84a56758cc096c3
-      size: 27886826
+      md5: 6dc1e512ee4027a1ec1a0f77f9888aa6
+      size: 2951
     - path: update_golden.py
-      md5: 6296d6779d4c4dca2321ae6519c905ea
-      size: 3545
-  validate:
-    cmd:
-    - python ./FinalFile/ge_validate.py
-    - zip -r ./FinalFile/Reports/report_$(date +"%m-%d-%Y-%H_%M_%S").zip ./great_expectations/uncommitted/data_docs
+      md5: 8310b9ac0745597205c9a66c29a10242
+      size: 3556

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -30,7 +30,6 @@ stages:
     cmd: python combine_csvs_and_jsons.py
     deps:
     - combine_csvs_and_jsons.py
-    - ../AskNature/taxonomy/converted_paper.csv
     outs:
     - merged_dataframes.csv
 

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -30,6 +30,7 @@ stages:
     cmd: python combine_csvs_and_jsons.py
     deps:
     - combine_csvs_and_jsons.py
+    - ../AskNature/taxonomy/converted_paper.csv
     outs:
     - merged_dataframes.csv
 


### PR DESCRIPTION
MergeOnly would fail from a dependency that doesn't exist (nor needs to exist for this action) from earlier in the pipeline. I've removed that, tweaked the command to force the pipeline to run at and after the middle stage. I also noticed an inconsistency with DOI parsing that I have fixed.