### PR TITLE
David branch

### DIFF
--- a/LabeledData/convert_with_api.py
+++ b/LabeledData/convert_with_api.py
@@ -195,7 +195,7 @@ def convert_to_json(dataframe: pd.DataFrame, api_res: list, api_dois: list):
                     temp_dict["abstract"] = ""
 
                 # Open Access
-                temp_dict["isOpenAccess"] = api_paper["open_access"]["is_oa"]
+                temp_dict["isOpenAccess"] = bool(api_paper["open_access"]["is_oa"])
                 # Full Doc Link
                 temp_dict["fullDocLink"] = api_paper["open_access"]["oa_url"]
                 

--- a/LabeledData/convert_with_api.py
+++ b/LabeledData/convert_with_api.py
@@ -7,6 +7,7 @@ import requests
 import traceback
 import os
 import argparse
+import ast
 
 # Global Variables
 stopwords = nltk.corpus.stopwords.words('english')
@@ -129,8 +130,14 @@ def convert_to_json(dataframe: pd.DataFrame, api_res: list, api_dois: list):
             if (api_index >= 0):
                 temp_dict["paper"] = extract_oa_id(api_paper["id"])
                 # Mesh Terms
-                if (api_paper["mesh"]):
-                    temp_dict["mesh_terms"] = [mesh["descriptor_name"] for mesh
+                if (len(api_paper["mesh"])):
+
+                    # Safely evaluate as object if stringified
+                    if (isinstance(api_paper["mesh"][0], str)):
+                        temp_dict["mesh_terms"] = [ast.literal_eval(mesh)["descriptor_name"] for mesh
+                        in api_paper["mesh"]]    
+                    else:
+                        temp_dict["mesh_terms"] = [mesh["descriptor_name"] for mesh
                         in api_paper["mesh"]]
                 else:
                     temp_dict["mesh_terms"] = []


### PR DESCRIPTION
**Summary**

I have updated the api code to convert the string representation of an object, back into an object if OpenAlex returns a string in its place. This update has been made because OpenAlex appears to have made this formatting change for their MeSH field with no warning.

I have also updated the pipeline to treat the OpenAccess field from OpenAlex as a boolean rather than a double.

Finally, I have updated the reference golden.json to replace the double isOpenAccess fields with their boolean counterparts.