### PR TITLE
David branch

### DIFF
--- a/LabeledData/convert_with_api.py
+++ b/LabeledData/convert_with_api.py
@@ -129,15 +129,10 @@ def convert_to_json(dataframe: pd.DataFrame, api_res: list, api_dois: list):
 
             if (api_index >= 0):
                 temp_dict["paper"] = extract_oa_id(api_paper["id"])
+                
                 # Mesh Terms
                 if (len(api_paper["mesh"])):
-
-                    # Safely evaluate as object if stringified
-                    if (isinstance(api_paper["mesh"][0], str)):
-                        temp_dict["mesh_terms"] = [ast.literal_eval(mesh)["descriptor_name"] for mesh
-                        in api_paper["mesh"]]    
-                    else:
-                        temp_dict["mesh_terms"] = [mesh["descriptor_name"] for mesh
+                    temp_dict["mesh_terms"] = [mesh["descriptor_name"] for mesh
                         in api_paper["mesh"]]
                 else:
                     temp_dict["mesh_terms"] = []


### PR DESCRIPTION
**Summary**

These changes were made under the assumption the API formatting was updated. It was later figured out the MeSH terms in the API have been broken by some update. I am removing this work around as the developers have said that they are going to fix the problem. I would rather the pipeline break along with the API rather than introduce possibly malformed fields.